### PR TITLE
Specify plugin category/features for LV2, VST3, and CLAP

### DIFF
--- a/src/DistrhoPluginInfo.h
+++ b/src/DistrhoPluginInfo.h
@@ -45,6 +45,21 @@
 #define DISTRHO_PLUGIN_URI "https://lucianoiam.com/castello-reverb"
 
 /**
+   Custom LV2 category for the plugin.@n
+*/
+#define DISTRHO_PLUGIN_LV2_CATEGORY "lv2:ReverbPlugin"
+
+/**
+   Custom VST3 categories for the plugin.@n
+*/
+#define DISTRHO_PLUGIN_VST3_CATEGORIES "Fx|Reverb"
+
+/**
+   Custom CLAP features for the plugin.@n
+*/
+#define DISTRHO_PLUGIN_CLAP_FEATURES "audio-effect", "reverb", "stereo"
+
+/**
    The plugin id when exporting in CLAP format, in reverse URI form.
    @note This macro is required when building CLAP plugins
 */


### PR DESCRIPTION
Following the example [here](https://github.com/DISTRHO/DPF/blob/22413340a6d8ef2ffbf38ce841fb44c448a1a84a/distrho/DistrhoInfo.hpp#L715), I added macros to specify the plugin category/features for LV2, VST3, and CLAP builds, since plugin hosts typically expect this information.

I haven't built it to test it yet.
